### PR TITLE
[qmsystem] Add support for host mode switching and dedicated charger.

### DIFF
--- a/qmsystem2-qt5.pc
+++ b/qmsystem2-qt5.pc
@@ -4,7 +4,7 @@ libdir=${prefix}/lib/
 
 Name: QmSystem2
 Description: QmSystem2 Library
-Version: 1.4.15
+Version: 1.4.17
 Requires: Qt5Core timed-qt5
 Libs: -L${libdir} -lqmsystem2-qt5
 Cflags: -I${includedir}/qmsystem2-qt5

--- a/qmsystem2.pc
+++ b/qmsystem2.pc
@@ -4,7 +4,7 @@ libdir=${prefix}/lib/
 
 Name: QmSystem2
 Description: QmSystem2 Library
-Version: 1.4.15
+Version: 1.4.17
 Requires: QtCore timed
 Libs: -L${libdir} -lqmsystem2
 Cflags: -I${includedir}/qmsystem2

--- a/rpm/qmsystem-qt5.spec
+++ b/rpm/qmsystem-qt5.spec
@@ -9,7 +9,7 @@ Name:       qmsystem-qt5
 # << macros
 
 Summary:    QmSystem library
-Version:    1.4.15
+Version:    1.4.17
 Release:    1
 Group:      System/System Control
 License:    LGPLv2

--- a/rpm/qmsystem-qt5.yaml
+++ b/rpm/qmsystem-qt5.yaml
@@ -1,6 +1,6 @@
 Name: qmsystem-qt5
 Summary: QmSystem library
-Version: 1.4.15
+Version: 1.4.17
 Release: 1
 Group: System/System Control
 License: LGPLv2

--- a/rpm/qmsystem.spec
+++ b/rpm/qmsystem.spec
@@ -9,7 +9,7 @@ Name:       qmsystem
 # << macros
 
 Summary:    QmSystem library
-Version:    1.4.15
+Version:    1.4.17
 Release:    1
 Group:      System/System Control
 License:    LGPLv2

--- a/rpm/qmsystem.yaml
+++ b/rpm/qmsystem.yaml
@@ -1,6 +1,6 @@
 Name: qmsystem
 Summary: QmSystem library
-Version: 1.4.15
+Version: 1.4.17
 Release: 1
 Group: System/System Control
 License: LGPLv2

--- a/system/msystemdbus_p.h
+++ b/system/msystemdbus_p.h
@@ -99,6 +99,7 @@
     #define MODE_MTP                        "mtp_mode"
     #define MODE_ADB                        "adb_mode"
     #define MODE_DIAG                       "diag_mode"
+    #define MODE_HOST			    "host_mode"
     #define MODE_CONNECTION_SHARING	    "connection_sharing"
 #endif /* HAVE_USB_MODED_DEV */
 

--- a/system/msystemdbus_p.h
+++ b/system/msystemdbus_p.h
@@ -101,6 +101,7 @@
     #define MODE_DIAG                       "diag_mode"
     #define MODE_HOST			    "host_mode"
     #define MODE_CONNECTION_SHARING	    "connection_sharing"
+    #define MODE_CHARGER                    "dedicated_charger"
 #endif /* HAVE_USB_MODED_DEV */
 
 #endif // MSYSTEMDBUS_P_H

--- a/system/qmusbmode.cpp
+++ b/system/qmusbmode.cpp
@@ -194,7 +194,7 @@ bool QmUSBMode::setMode(QmUSBMode::Mode mode) {
 
     // The OviSuite, MassStorage, ChargingOnly and SDK modes can be requested
     if (!(OviSuite == mode || MassStorage == mode || ChargingOnly == mode || SDK == mode || Developer == mode || 
-	  MTP == mode || Adb == mode || Diag == mode || Host == mode || ConnectionSharing == mode)) {
+         MTP == mode || Adb == mode || Diag == mode || Host == mode || ConnectionSharing == mode || Charger == mode)) {
         return false;
     }
 
@@ -215,7 +215,8 @@ bool QmUSBMode::setDefaultMode(QmUSBMode::Mode mode) {
 
     // The OviSuite, MassStorage, ChargingOnly and Ask modes can be requested
     if (!(OviSuite == mode || MassStorage == mode || ChargingOnly == mode || SDK == mode || Developer == mode || 
-	  MTP == mode || Adb == mode || Diag == mode || Host == mode || Ask == mode || ConnectionSharing == mode)) {
+         MTP == mode || Adb == mode || Diag == mode || Host == mode || Ask == mode || ConnectionSharing == mode ||
+         Charger == mode )) {
         return false;
     }
 
@@ -313,12 +314,14 @@ QString QmUSBModePrivate::modeToString(QmUSBMode::Mode mode) {
 	return MODE_ADB;
     case QmUSBMode::Diag:
 	return MODE_DIAG;
-    case QmUSBMode::Host:
-	return MODE_HOST;
     case QmUSBMode::Developer:
 	return MODE_DEVELOPER;
     case QmUSBMode::ConnectionSharing:
 	return MODE_CONNECTION_SHARING;
+    case QmUSBMode::Host:
+	return MODE_HOST;
+    case QmUSBMode::Charger:
+        return MODE_CHARGER;
     default:
         return "";
     }
@@ -351,12 +354,14 @@ QmUSBMode::Mode QmUSBModePrivate::stringToMode(const QString &str) {
 	return QmUSBMode::Adb;
     } else if (str == MODE_DIAG) {
 	return QmUSBMode::Diag;
-    } else if (str == MODE_HOST) {
-	return QmUSBMode::Host;
     } else if (str == MODE_DEVELOPER) {
 	return QmUSBMode::Developer;
     } else if (str == MODE_CONNECTION_SHARING) {
 	return QmUSBMode::ConnectionSharing;
+    } else if (str == MODE_HOST) {
+	return QmUSBMode::Host;
+    } else if (str == MODE_CHARGER) {
+        return QmUSBMode::Charger;
     } else {
         return QmUSBMode::Undefined;
     }

--- a/system/qmusbmode.cpp
+++ b/system/qmusbmode.cpp
@@ -194,7 +194,7 @@ bool QmUSBMode::setMode(QmUSBMode::Mode mode) {
 
     // The OviSuite, MassStorage, ChargingOnly and SDK modes can be requested
     if (!(OviSuite == mode || MassStorage == mode || ChargingOnly == mode || SDK == mode || Developer == mode || 
-	  MTP == mode || Adb == mode || Diag == mode || ConnectionSharing == mode)) {
+	  MTP == mode || Adb == mode || Diag == mode || Host == mode || ConnectionSharing == mode)) {
         return false;
     }
 
@@ -215,7 +215,7 @@ bool QmUSBMode::setDefaultMode(QmUSBMode::Mode mode) {
 
     // The OviSuite, MassStorage, ChargingOnly and Ask modes can be requested
     if (!(OviSuite == mode || MassStorage == mode || ChargingOnly == mode || SDK == mode || Developer == mode || 
-	  MTP == mode || Adb == mode || Diag == mode || Ask == mode || ConnectionSharing == mode)) {
+	  MTP == mode || Adb == mode || Diag == mode || Host == mode || Ask == mode || ConnectionSharing == mode)) {
         return false;
     }
 
@@ -313,6 +313,8 @@ QString QmUSBModePrivate::modeToString(QmUSBMode::Mode mode) {
 	return MODE_ADB;
     case QmUSBMode::Diag:
 	return MODE_DIAG;
+    case QmUSBMode::Host:
+	return MODE_HOST;
     case QmUSBMode::Developer:
 	return MODE_DEVELOPER;
     case QmUSBMode::ConnectionSharing:
@@ -349,6 +351,8 @@ QmUSBMode::Mode QmUSBModePrivate::stringToMode(const QString &str) {
 	return QmUSBMode::Adb;
     } else if (str == MODE_DIAG) {
 	return QmUSBMode::Diag;
+    } else if (str == MODE_HOST) {
+	return QmUSBMode::Host;
     } else if (str == MODE_DEVELOPER) {
 	return QmUSBMode::Developer;
     } else if (str == MODE_CONNECTION_SHARING) {

--- a/system/qmusbmode.h
+++ b/system/qmusbmode.h
@@ -84,7 +84,8 @@ public:
 	MTP,		  //!< MTP mode. Allows for generic MTP
 	Adb,		  //!< adb mode. Allows Android Debug Bridge
 	Diag,		  //!< diag mode. Allows Qualcomm Diag
-	ConnectionSharing //!< Cellular connection sharing/tethering. 
+	ConnectionSharing, //!< Cellular connection sharing/tethering.
+	Host,		  //!< host mode. Allows switching to host mode
     };
 
     /*!

--- a/system/qmusbmode.h
+++ b/system/qmusbmode.h
@@ -86,6 +86,7 @@ public:
 	Diag,		  //!< diag mode. Allows Qualcomm Diag
 	ConnectionSharing, //!< Cellular connection sharing/tethering.
 	Host,		  //!< host mode. Allows switching to host mode
+        Charger,         //!<Dedicated charger is connected.
     };
 
     /*!


### PR DESCRIPTION
Add support for switching to host mode (if supported) in case host mode is not implemented natively and needs an external 5V, and manual switching of the device.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
